### PR TITLE
Фикс обновления BattlEye

### DIFF
--- a/lists/list-general.txt
+++ b/lists/list-general.txt
@@ -42,3 +42,4 @@ ffzap.com
 betterttv.net
 7tv.app
 7tv.io
+cdn.battleye.com


### PR DESCRIPTION
Видимо РКН занюхал чуток запрещенного, да такого количества, что от этого аж пострадал CDN сервак BattlEye, вследствие чего - произошел отвал обновления античита и невозможности поиграть в мультиплеер